### PR TITLE
serverless: AWS_API_GATEWAY_SPECIFIC_KEYS 対応

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,8 +23,9 @@ provider:
     lambda: true
   logRetentionInDays: 14
   endpointType: regional
-  apiKeys:
-    - ${self:provider.stage}-myFirstKey
+  apiGateway:
+    apiKeys:
+      - ${self:provider.stage}-myFirstKey
 package:
   patterns:
     - app/**


### PR DESCRIPTION
https://www.serverless.com/framework/docs/deprecations/#AWS_API_GATEWAY_SPECIFIC_KEYS